### PR TITLE
There are a few things that I have added as part of this checkin.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,10 +5,10 @@ module.exports = function(grunt) {
         banner;
 
     banner = "/*! <%= pkg.name %> - v<%= pkg.version %> - " +
-            "<%= grunt.template.today('yyyy-mm-dd') %>\n" +
-            "<%= pkg.homepage ? '* ' + pkg.homepage + '\\n' : '' %>" +
-            "* Copyright (c) <%= grunt.template.today('yyyy') %> <%= pkg.author.name %>;" +
-            " Licensed <%= _.pluck(pkg.licenses, 'type').join(', ') %> */\n";
+        "<%= grunt.template.today('yyyy-mm-dd') %>\n" +
+        "<%= pkg.homepage ? '* ' + pkg.homepage + '\\n' : '' %>" +
+        "* Copyright (c) <%= grunt.template.today('yyyy') %> <%= pkg.author.name %>;" +
+        " Licensed <%= _.pluck(pkg.licenses, 'type').join(', ') %> */\n";
 
     require("time-grunt")(grunt);
     //Load our custom tasks
@@ -23,11 +23,20 @@ module.exports = function(grunt) {
             devServerPort: 9998
         },
         loadGruntTasks: { //can optionally pass options to load-grunt-tasks.  If you set to false, it will disable auto loading tasks.
-            pattern:  ["grunt-*", "intern"]
+            pattern: ["grunt-*", "intern"]
         }
     });
+
+    grunt.initConfig({
+        nodeunit: {
+            all: ["test/*-test.js"],
+            options: {
+                reporter: 'verbose'
+            }
+        },
+    });
     // Actually load this plugin's task(s).
-    grunt.loadTasks('tasks');
+    grunt.loadTasks("tasks");
 
     //Linting tasks
     grunt.registerTask("lint", ["jshint", "jscs"]);
@@ -36,5 +45,7 @@ module.exports = function(grunt) {
     grunt.registerTask("documentation", ["jsdoc"]);
 
     // Default task.
-    grunt.registerTask("default", ["clean:build", "lint", "documentation"]);
+    grunt.registerTask("default", [/*"clean:build"*/, "lint", "documentation"]);
+
+    grunt.registerTask("test", ["nodeunit"]);
 };

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ the default threshold values are
         }
 ```
 
+You can also provide multiple configurations for different features/packages of your project.
+
 ### Options
 
 #### lines
@@ -195,6 +197,29 @@ grunt.initConfig({
   },
 })
 ```
+
+With 0.2.0 release you will be able to customize the code-coverage on and individual folder level.  The configuration options to provide code-coverage on an individual folder can be specified in the following way:
+
+```js
+grunt.initConfig({
+  "code-coverage-enforcer": {
+    options: {
+        lcovfile: "lcov.info",
+        lines: 60, //Global line coverage configuration
+        functions: 60, // Global function coverage configuration
+        branches: 60, // Global branch coverage configuration
+        src: [{path:"middleware", lines:90}, {path:"backend", lines: 90, functions: 80}, {path:"frontend", lines: 90, functions: 80, branches:70, includes:["**.js"], excludes:["frontend/exclude.js"]}
+        includes: ["src/**/*.js"],
+        excludes: ["src/uncoveredfile.js"]
+    }
+  },
+})
+```
+If any configuration option is not provided on an individual folder level, the default configurations are chosen.  In the above example we configured our project to have the following three coverage configuration
+
+1.  90% line coverage, 60% function coverage, 60% branch coverage for all the files in middleware folder.
+2.  90% line coverage, 80% function coverage, 60% branch coverage for all the files in backend folder.
+3.  90% line coverage, 80% function coverage, 70% branch coverage for all the files in frontend folder except exclude.js file.
 
 
 ### Recommendations

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ grunt.initConfig({
 })
 ```
 
-With 0.2.0 release you will be able to customize the code-coverage on and individual folder level.  The configuration options to provide code-coverage on an individual folder can be specified in the following way:
+With the release of version 0.2.0,  you will be able to customize the code-coverage on and individual folder/package level.  The configuration options on an individual folder/package level can be specified in the following way:
 
 ```js
 grunt.initConfig({
@@ -208,19 +208,34 @@ grunt.initConfig({
         lines: 60, //Global line coverage configuration
         functions: 60, // Global function coverage configuration
         branches: 60, // Global branch coverage configuration
-        src: [{path:"middleware", lines:90}, {path:"backend", lines: 90, functions: 80}, {path:"frontend", lines: 90, functions: 80, branches:70, includes:["**.js"], excludes:["frontend/exclude.js"]}
+        src: [{
+          path:"middleware", 
+          lines:90
+        }, {
+          path:"backend", 
+          lines: 90, 
+          functions: 80
+        }, {
+          path:"frontend", 
+          lines: 90, 
+          functions: 80,
+          branches:70, 
+          includes:["**.js"], 
+          excludes:["frontend/exclude.js"]
+        }
         includes: ["src/**/*.js"],
         excludes: ["src/uncoveredfile.js"]
     }
   },
 })
 ```
-If any configuration option is not provided on an individual folder level, the default configurations are chosen.  In the above example we configured our project to have the following three coverage configuration
+In the above example we configured our project to have the following three coverage configuration
 
 1.  90% line coverage, 60% function coverage, 60% branch coverage for all the files in middleware folder.
 2.  90% line coverage, 80% function coverage, 60% branch coverage for all the files in backend folder.
 3.  90% line coverage, 80% function coverage, 70% branch coverage for all the files in frontend folder except exclude.js file.
 
+If any of the configuration option is not provided for a given folder/package, the default configurations are chosen.
 
 ### Recommendations
 

--- a/package.json
+++ b/package.json
@@ -28,16 +28,17 @@
     "json-stringify-safe": "5.0.0"
   },
   "devDependencies": {
+    "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-nodeunit": "~0.3.0",
-    "grunt": "~0.4.2",
-    "jshint-stylish": "~0.1.5",
-    "load-grunt-tasks": "~0.3.0",
-    "load-grunt-config": "^0.8.0",
+    "grunt-debug-task": "^0.1.5",
     "grunt-jscs-checker": "0.4.2",
     "grunt-jsdoc": "0.5.4",
     "intern": "1.6.2",
+    "jshint-stylish": "~0.1.5",
+    "load-grunt-config": "^0.8.0",
+    "load-grunt-tasks": "~0.3.0",
     "time-grunt": "0.3.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-code-coverage-enforcer",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Enforces code coverage thresholds for a project with lcov files.",
   "homepage": "https://github.com/tapasvimoturu/grunt-code-coverage-enforcer",
   "author": {

--- a/tasks/code-coverage-enforcer.js
+++ b/tasks/code-coverage-enforcer.js
@@ -29,7 +29,9 @@ var fs = require("fs"),
     path = require("path"),
     stringify = require("json-stringify-safe"),
     shjs = require("shelljs"),
-    minimatch = require("minimatch");
+    util = require("./lib/code-coverage-enforcer-lib"),
+    minimatch = require("minimatch"),
+    grunt = require("grunt");
 
 /**
  * This is a grunt task that reads a specified Lcov file and checks if the code coverage for the specified files in options meets a
@@ -55,380 +57,30 @@ module.exports = function(grunt) {
                 functions: 50,
                 branches: 0,
                 includes: ["**/*.js"],
-                src: process.cwd(),
+                src: process.cwd(), //array { path: "",thresholds: {} }
                 excludes: []
-            }),
-
-            /* This method is a decorator used to normalize the file names that are created by LCOV reporters. For ex. Intern's default LCOV reporter
-             * has the filename when it is in the current folder but Karma add as ./ in front of the file
-             */
-            normalizeFilename = function(filename) {
-                if (filename.substring(0, 2) === "./") {
-                    filename = filename.substring(2);
-                } else if (filename.substring(0, 1) === "/") {
-                    filename = filename.substring(1);
-                }
-                return filename;
-            };
-
-        /**
-         * This function reads the lcov string and converts it into a json object structure similar to the one below
-         *
-         */
-        parseLcovContent = function(lcovRawString, callback) {
-            //grunt.verbose.writeln("lcov content" + lcovRawString);
-            var lcovData = [],
-                item = {
-                    file: undefined,
-                    lines: {
-                        found: 0,
-                        hit: 0
-
-                    },
-                    functions: {
-                        hit: 0,
-                        found: 0
-                    },
-                    branches: {
-                        hit: 0,
-                        found: 0
-                    }
-                },
-                infoEntries = lcovRawString.split("\n");
-
-            infoEntries.forEach(function(entry, index) {
-                entry = entry.trim();
-                var parts = entry.split(":"),
-                    lines, fn;
-                switch (parts[0].toUpperCase()) {
-                    case "SF":
-                        item.file = parts.slice(1).join(":").trim();
-                        item.file = normalizeOSPath(item.file);
-                        break;
-                    case "FNF":
-                        item.functions.found = Number(parts[1].trim());
-                        break;
-                    case "FNH":
-                        item.functions.hit = Number(parts[1].trim());
-                        break;
-                    case "LF":
-                        item.lines.found = Number(parts[1].trim());
-                        break;
-                    case "LH":
-                        item.lines.hit = Number(parts[1].trim());
-                        break;
-                    case "BRF":
-                        item.branches.found = Number(parts[1]);
-                        break;
-                    case "BRH":
-                        item.branches.hit = Number(parts[1]);
-                        break;
-                }
-
-                if (entry.indexOf("end_of_record") > -1) {
-                    lcovData.push(item);
-                    // Resetting item to a new Json object after pushing.
-                    item = {
-                        file: undefined,
-                        lines: {
-                            found: 0,
-                            hit: 0
-
-                        },
-                        functions: {
-                            hit: 0,
-                            found: 0
-                        },
-                        branches: {
-                            hit: 0,
-                            found: 0
-                        }
-                    };
-                }
-
-                if (index === infoEntries.length - 1) {
-                    grunt.verbose.writeln("processing callback with " + stringify(lcovData, null, 2));
-                    callback(lcovData);
-                }
             });
-        };
-
-        /**
-         * This function is going to read the specified file synchronously and then call the provided callback with the string content.
-         * @param  {string}   file     The filename to be read.
-         * @param  {Function} callback The callback to be called on successful read.
-         * @return {string}            The contents of the file in string format.
-         */
-        readFile = function(file, callback) {
-            grunt.verbose.writeln("Checking if file exists ... " + file);
-            var content = fs.readFileSync(file, "utf8");
-            if (content) {
-                grunt.verbose.ok();
-                callback(content);
-            } else {
-                grunt.fail.warn("Could not read from lcov file. Please ensure that that file exists");
-            }
-        };
-
-        /**
-         * This function checks if the
-         * @param  {Array} data  An array that contains the parsed contents of the lcov file.  See
-         * @return {none}
-         */
-        checkThresholdValidity = function(data) {
-            //grunt.verbose.writeln("Processing LcovData:" + data);
-            var pass = true,
-                length = data.length,
-                fileList = [],
-                isFileExcluded = function(fileList, filename) {
-                    var excluded = true;
-                    filename = normalizeFilename(filename);
-
-                    fileList.forEach(function(f, index) {
-                        if (f === filename) {
-                            excluded = false;
-                        }
-
-                    });
-                    //grunt.verbose.writeln("Checking if file is excluded: " + filename + "excluded:" + excluded);
-                    return excluded;
-                };
-
-            grunt.log.writeln("------------------------------------------------------------------");
-            grunt.log.writeln("Scanning folder for files");
-            grunt.log.writeln("------------------------------------------------------------------");
-
-            collect(options.src, fileList, options.includes, options.excludes, null);
-
-            fileList.forEach(function(filename, index) {
-                grunt.verbose.writeln("Included:" + filename);
-            });
-            grunt.log.writeln("------------------------------------------------------------------");
-            grunt.log.writeln("Threshold configuration: lines:" + options.lines + "%, functions:" + options.functions + "%, branches:" + options.branches + "%");
-            grunt.log.writeln("------------------------------------------------------------------");
-
-            data.forEach(function(fileData, index) {
-                var lineThreshold = 100,
-                    functionThreshold = 100,
-                    branchesThreshold = 100;
-                if (fileData.lines.hit > 0) {
-                    lineThreshold = fileData.lines.hit * 100 / fileData.lines.found;
-                    lineThreshold = lineThreshold.toFixed(2);
-                }
-
-                if (fileData.functions.hit > 0) {
-                    functionThreshold = fileData.functions.hit * 100 / fileData.functions.found;
-                    functionThreshold = functionThreshold.toFixed(2);
-                }
-
-                if (fileData.branches.hit > 0) {
-                    branchesThreshold = fileData.branches.hit * 100 / fileData.branches.found;
-                    branchesThreshold = branchesThreshold.toFixed(2);
-                }
-
-                var fileName = fileData.file.replace(process.cwd(), "");
-
-                fileName = normalizeFilename(fileName);
-
-                grunt.log.writeln("File:" + fileName);
-                grunt.log.write("lines:" + lineThreshold + "% | ");
-                grunt.log.write("functions:" + functionThreshold + "% | ");
-                grunt.log.write("branches:" + branchesThreshold + "% | ");
-                var excluded = isFileExcluded(fileList, fileName);
-
-                if (lineThreshold >= options.lines && functionThreshold >= options.functions && branchesThreshold >= options.branches) {
-
-                    if (excluded) {
-                        grunt.log.ok("EXCLUDED");
-                    } else {
-                        grunt.log.ok();
-                    }
-
-                } else {
-
-                    if (excluded) {
-                        grunt.log.ok("EXCLUDED");
-                    } else {
-                        grunt.log.error();
-                        pass = false;
-                    }
-
-                }
-
-            });
-
-            fileList.forEach(function(filename, index) {
-                //grunt.verbose.writeln("checking file coverage in LcovData:" + filename);
-                var representedInLcov = false;
-                data.forEach(function(fileData, index) {
-                    var lcov = fileData.file.replace(process.cwd(), "");
-                    lcov = normalizeFilename(lcov);
-                    //grunt.verbose.writeln("Comparing filenames:" + lcov +"," + filename);
-                    if (lcov === filename) {
-                        representedInLcov = true;
-                    }
-                });
-                if (representedInLcov === false) {
-                    grunt.log.error("FAILED file:" + filename + " :: Has no code coverage data. Ensure that the source file is represented in test coverage (lcov) data");
-                    pass = false;
-                }
-            });
-
-            if (pass === false) {
-                grunt.fail.warn("Failed to meet code coverage threshold requirements");
-            }
-
-        };
-
-        /**
-         * Gathers all files that need to be checked for threshold validity.
-         * @param {object} opts  options that include the src folder, includes and excludes.
-         *
-         */
-        gather = function(opts) {
-            var files = [],
-                excludes = options.exclude,
-                includes = options.src;
-
-            opts.args.forEach(function(target) {
-                collect(target, files, includes, excludes);
-            });
-
-            return files;
-        };
-
-        /**
-         * Recursively gather all files that need to be processed,
-         * excluding those that user asked to ignore.
-         *
-         * @param {string} fp      a path to a file or directory to lint
-         * @param {array}  files   a pointer to an array that stores a list of files
-         * @param {array}  includes a list of patterns for files to math
-         * @param {array}  excludes a list of patterns for files to ignore
-         */
-        collect = function(fp, files, includes, excludes) {
-            //grunt.verbose.writeln("trying to collect: " + fp +",filesLength:" + files.length +",includes:" + includes + ",excludes:"+excludes);
-            //grunt.verbose.writeln("  testing for excludes");
-
-            if (excludes && isMatched(fp, excludes)) {
-                grunt.log.writeln("Exluded: " + fp);
-                return;
-            }
-
-            if (!shjs.test("-e", fp)) {
-                grunt.verbose.error("Can't open " + fp);
-                return;
-            }
-            //grunt.verbose.writeln("  testing for files");
-
-            if (shjs.test("-f", fp) || shjs.test("-L", fp)) {
-
-                if (isMatched(fp, includes)) {
-                    // /grunt.verbose.writeln("pushing file 1:" + fp);
-                    files.push(fp);
-                }
-                return;
-            }
-
-            //grunt.verbose.writeln("  testing for directory");
-
-            if (shjs.test("-d", fp)) {
-                grunt.verbose.writeln("Collecting directory:" + fp);
-                shjs.ls(fp).forEach(function(item) {
-
-                    var itempath = path.join(fp, item);
-                    if (shjs.test("-d", itempath)) {
-                        collect(itempath, files, includes, excludes);
-                    } else {
-
-                        collect(itempath, files, includes, excludes);
-                        return;
-                    }
-                });
-
-                return;
-            }
-        };
-
-        /**
-         * Checks whether a file matches the list of patterns specified.
-         *
-         * @param {string} fp       a path to a file
-         * @param {array}  patterns a list of patterns for files  matching
-         *
-         * @return {boolean} "true" if file matches, "false" if file doesnt match.
-         */
-        isMatched = function(fp, patterns) {
-            //grunt.verbose.writeln("Matching file:" + fp +" with pattern:" + patterns);
-            return patterns.some(function(ip) {
-                //grunt.verbose.writeln("  checking for match with: " + ip);
-                var file = path.resolve(fp).replace(process.cwd(), "").trim();
-
-                file = normalizeFilename(file);
-
-                if (minimatch(file, ip, {
-                    nocase: true
-                })) {
-                    //grunt.verbose.writeln(file + ", Matched::file with regular expression");
-                    return true;
-                }
-
-                if (file === ip) {
-                    //grunt.verbose.writeln(fp + ", Matched::file exactly");
-                    return true;
-                }
-
-                if (shjs.test("-d", fp) && ip.match(/^[^\/]*\/?$/) &&
-                    file.match(new RegExp("^" + ip))) {
-                    //grunt.verbose.writeln(fp+ ", Matched::regular expression:" + "^" + ip + "*" );
-                    return true;
-                }
-                //grunt.verbose.writeln(fp + ", Did not Match");
-                return false;
-            });
-        };
-
-        //normalizing all path properties.
-        normalizeOSPath = function(fp) {
-            var arr = [],
-                normalizeFile = function(f) {
-                    if (path.sep === "\\") {
-                        //Current Machine is windows style
-                        f = f.replace(/\//g, "\\");
-                    } else {
-                        //Current Machine is unix style
-                        f = f.replace(/\\/g, "/");
-
-                    }
-                    return f;
-                };
-
-            if (fp instanceof Array) {
-                fp.forEach(function(file) {
-                    arr.push(normalizeFile(file));
-                });
-                return arr;
-            } else {
-                return normalizeFile(fp);
-
-            }
-        };
+        
 
         grunt.verbose.writeln("Checking code coverage for threshold limits ....");
         grunt.verbose.writeln("Reading the lcov file ....");
 
-        options.lcovfile = normalizeOSPath(options.lcovfile);
-        options.includes = normalizeOSPath(options.includes);
-        options.excludes = normalizeOSPath(options.excludes);
-        options.src = normalizeOSPath(options.src);
+        options.lcovfile = util.normalizeOSPath(options.lcovfile);
+        options.includes = util.normalizeOSPath(options.includes);
+        options.excludes = util.normalizeOSPath(options.excludes);
+
+        //Adapt the original options to the list of configs that will be used for validating the code coverage.
+        options.src = util.normalizeSrcToObj(options.src, options.lines, options.functions, options.branches, options.includes, options.excludes);
+        // options.src = util.normalizeOSPath(options.src);
 
         if (options.lcovfile) {
             grunt.verbose.writeln("Processing File:" + options.lcovfile);
-            readFile(options.lcovfile, function(content) {
-                parseLcovContent(content, function(lcovJson) {
-                    var files = [];
-
-                    checkThresholdValidity(lcovJson);
+            //Read the lcov file and pass the contents of the file to the anonymous function.
+            util.readFile(options.lcovfile, function(content) {
+                //parse the lcov content and pass the json representation of the data to the anonymous function.
+                util.parseLcovContent(content, function(lcovJson) {
+                    //Check the threshold validity using the lcovJson with all the passed in configs
+                    util.checkThresholdValidity(lcovJson, options.src);
                 });
             });
         }

--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -488,7 +488,7 @@ module.exports = (function() {
             configs = src;
             configs.forEach(function(conf) {
 
-                if(!config.lines) {
+                if(!conf.lines) {
                     conf.lines = lines;
                 }
 

--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -1,0 +1,524 @@
+/**
+ * Copyright 2014 Intuit Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the Intuit! Inc. nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+var fs = require("fs"),
+    path = require("path"),
+    stringify = require("json-stringify-safe"),
+    shjs = require("shelljs"),
+    minimatch = require("minimatch"),
+    grunt = require("grunt");
+
+
+module.exports = (function() {
+
+    "use strict";
+
+    // Add public functions to exports object to be used by the Grunt integration.
+    var exports = {};
+
+    /* 
+     * This method is a decorator used to normalize the file names that are created by LCOV reporters. For ex. Intern's default LCOV reporter
+     * has the filename when it is in the current folder but Karma add as ./ in front of the file
+     */
+    exports.normalizeFileName = function(filename) {
+        if (filename.substring(0, 2) === "./") {
+            filename = filename.substring(2);
+        } else if (filename.substring(0, 1) === "/") {
+            filename = filename.substring(1);
+        }
+        return filename;
+    };
+
+    /**
+     * This function is going to read the specified file synchronously and then call the provided callback with the string content.
+     * @param  {string}   file     The filename to be read.
+     * @param  {Function} callback The callback to be called on successful read.
+     * @return {string}            The contents of the file in string format.
+     */
+    exports.readFile = function(file, callback) {
+        grunt.verbose.writeln("Checking if file exists ... " + file);
+        var content = fs.readFileSync(exports.normalizeFileName(file), "utf8");
+        if (content) {
+            grunt.verbose.ok();
+            callback(content);
+        } else {
+            grunt.fail.warn("Could not read from lcov file. Please ensure that that file exists");
+        }
+    };
+
+    /**
+     * This function reads the lcov string and converts it into a json object structure similar to the one below
+     *
+     */
+    exports.parseLcovContent = function(lcovRawString, callback) {
+        //grunt.verbose.writeln("lcov content" + lcovRawString);
+        var lcovData = [],
+            item = {
+                file: undefined,
+                lines: {
+                    found: 0,
+                    hit: 0
+
+                },
+                functions: {
+                    hit: 0,
+                    found: 0
+                },
+                branches: {
+                    hit: 0,
+                    found: 0
+                }
+            },
+            infoEntries = lcovRawString.split("\n");
+
+        infoEntries.forEach(function(entry, index) {
+            entry = entry.trim();
+            var parts = entry.split(":"),
+                lines, fn;
+            switch (parts[0].toUpperCase()) {
+                case "SF":
+                    item.file = parts.slice(1).join(":").trim();
+                    item.file = exports.normalizeOSPath(item.file);
+                    break;
+                case "FNF":
+                    item.functions.found = Number(parts[1].trim());
+                    break;
+                case "FNH":
+                    item.functions.hit = Number(parts[1].trim());
+                    break;
+                case "LF":
+                    item.lines.found = Number(parts[1].trim());
+                    break;
+                case "LH":
+                    item.lines.hit = Number(parts[1].trim());
+                    break;
+                case "BRF":
+                    item.branches.found = Number(parts[1]);
+                    break;
+                case "BRH":
+                    item.branches.hit = Number(parts[1]);
+                    break;
+            }
+
+            if (entry.indexOf("end_of_record") > -1) {
+                lcovData.push(item);
+                // Resetting item to a new Json object after pushing.
+                item = {
+                    file: undefined,
+                    lines: {
+                        found: 0,
+                        hit: 0
+
+                    },
+                    functions: {
+                        hit: 0,
+                        found: 0
+                    },
+                    branches: {
+                        hit: 0,
+                        found: 0
+                    }
+                };
+            }
+
+            if (index === infoEntries.length - 1) {
+                grunt.verbose.writeln("processing callback with " + stringify(lcovData, null, 2));
+                callback(lcovData);
+            }
+        });
+    };
+
+    //normalizing all path properties.
+    exports.normalizeOSPath = function(fp) {
+        var arr = [],
+            normalizeFile = function(f) {
+                if (path.sep === "\\") {
+                    //Current Machine is windows style
+                    f = f.replace(/\//g, "\\");
+                } else {
+                    //Current Machine is unix style
+                    f = f.replace(/\\/g, "/");
+
+                }
+                return f;
+            };
+
+        if (fp instanceof Array) {
+            fp.forEach(function(file) {
+                arr.push(normalizeFile(file));
+            });
+            return arr;
+        } else {
+            return normalizeFile(fp);
+
+        }
+    };
+    /**
+     * Checks whether a file matches the list of patterns specified.
+     *
+     * @param {string} fp       a path to a file
+     * @param {array}  patterns a list of patterns for files  matching
+     *
+     * @return {boolean} "true" if file matches, "false" if file doesnt match.
+     */
+    exports.isMatched = function(fp, patterns) {
+        //grunt.verbose.writeln("Matching file:" + fp +" with pattern:" + patterns);
+        return patterns.some(function(ip) {
+            //grunt.verbose.writeln("  checking for match with: " + ip);
+            var file = path.resolve(fp).replace(process.cwd(), "").trim();
+
+            file = exports.normalizeFileName(file);
+
+            if (minimatch(file, ip, {
+                    nocase: true
+                })) {
+                //grunt.verbose.writeln(file + ", Matched::file with regular expression");
+                return true;
+            }
+
+            if (file === ip) {
+                //grunt.verbose.writeln(fp + ", Matched::file exactly");
+                return true;
+            }
+
+            if (shjs.test("-d", fp) && ip.match(/^[^\/]*\/?$/) &&
+                file.match(new RegExp("^" + ip))) {
+                //grunt.verbose.writeln(fp+ ", Matched::regular expression:" + "^" + ip + "*" );
+                return true;
+            }
+            //grunt.verbose.writeln(fp + ", Did not Match");
+            return false;
+        });
+    };
+
+    /**
+     * Gathers all files that need to be checked for threshold validity.
+     * @param {object} opts  options that include the src folder, includes and excludes.
+     *
+     */
+    exports.gather = function(opts) {
+        var files = [],
+            excludes = options.exclude,
+            includes = options.src;
+
+        opts.args.forEach(function(target) {
+            collect(target, files, includes, excludes);
+        });
+
+        return files;
+    };
+
+    /**
+     * Recursively gather all files that need to be processed,
+     * excluding those that user asked to ignore.
+     *
+     * @param {string} fp      a path to a file or directory to lint
+     * @param {array}  files   a pointer to an array that stores a list of files
+     * @param {array}  includes a list of patterns for files to match
+     * @param {array}  excludes a list of patterns for files to ignore
+     *
+     * collect(options.src, fileList, options.includes, options.excludes, null);
+     */
+    exports.collect = function(fp, files, includes, excludes) {
+        //grunt.verbose.writeln("trying to collect: " + fp +",filesLength:" + files.length +",includes:" + includes + ",excludes:"+excludes);
+        //grunt.verbose.writeln("  testing for excludes");
+
+        if (excludes && exports.isMatched(fp, excludes)) {
+            grunt.log.writeln("Exluded: " + fp);
+            return;
+        }
+
+        if (!shjs.test("-e", fp)) {
+            grunt.verbose.error("Can't open " + fp);
+            return;
+        }
+        //grunt.verbose.writeln("  testing for files");
+
+        if (shjs.test("-f", fp) || shjs.test("-L", fp)) {
+
+            if (exports.isMatched(fp, includes)) {
+                // /grunt.verbose.writeln("pushing file 1:" + fp);
+                files.push(fp);
+            }
+            return;
+        }
+
+        //grunt.verbose.writeln("  testing for directory");
+
+        if (shjs.test("-d", fp)) {
+            grunt.verbose.writeln("Collecting directory:" + fp);
+            shjs.ls(fp).forEach(function(item) {
+
+                var itempath = path.join(fp, item);
+                if (shjs.test("-d", itempath)) {
+                    exports.collect(itempath, files, includes, excludes);
+                } else {
+                    exports.collect(itempath, files, includes, excludes);
+                    return;
+                }
+            });
+
+            return;
+        }
+    };
+
+    /**
+     * Checks whether a file matches the list of patterns specified.
+     *
+     * @param {string} fp       a path to a file
+     * @param {array}  patterns a list of patterns for files  matching
+     *
+     * @return {boolean} "true" if file matches, "false" if file doesnt match.
+     */
+    exports.isMatched = function(fp, patterns) {
+        //grunt.verbose.writeln("Matching file:" + fp +" with pattern:" + patterns);
+        return patterns.some(function(ip) {
+            //grunt.verbose.writeln("  checking for match with: " + ip);
+            var file = path.resolve(fp).replace(process.cwd(), "").trim();
+
+            file = exports.normalizeFileName(file);
+
+            if (minimatch(file, ip, {
+                    nocase: true
+                })) {
+                //grunt.verbose.writeln(file + ", Matched::file with regular expression");
+                return true;
+            }
+
+            if (file === ip) {
+                //grunt.verbose.writeln(fp + ", Matched::file exactly");
+                return true;
+            }
+
+            if (shjs.test("-d", fp) && ip.match(/^[^\/]*\/?$/) &&
+                file.match(new RegExp("^" + ip))) {
+                //grunt.verbose.writeln(fp+ ", Matched::regular expression:" + "^" + ip + "*" );
+                return true;
+            }
+            //grunt.verbose.writeln(fp + ", Did not Match");
+            return false;
+        });
+    };
+
+    /**
+     * This function checks if the source file that are included in the config object satisfies
+     * the code coverage threshold specified in the configuration.
+     *
+     * @param  {Array} data  An array that contains the parsed contents of the lcov file.  See
+     * @param  {config} data  Config for checking validity check for a specific folder.  See
+     * @return {none}
+     */
+    exports.checkThresholdValidityForConfig = function(data, config) {
+        var src = config.path,
+            lines = config.lines,
+            functions = config.functions,
+            branches = config.branches,
+            includes = config.includes,
+            excludes = config.excludes,
+            pass = true,
+            length = data.length,
+            fileList = [],
+            isFileExcluded = function(fileList, filename) {
+                var excluded = true;
+                filename = exports.normalizeFileName(filename);
+                fileList.forEach(function(f, index) {
+                    if (f === filename) {
+                        excluded = false;
+                    }
+
+                    f = exports.normalizeFileName(f.replace(process.cwd(),""));
+                    if(f === filename) {
+                        excluded = false;
+                    }
+                });
+                //grunt.verbose.writeln("Checking if file is excluded: " + filename + "excluded:" + excluded);
+                return excluded;
+            };
+        grunt.log.writeln("------------------------------------------------------------------");
+        grunt.log.writeln("Scanning folder for files");
+        grunt.log.writeln("------------------------------------------------------------------");
+
+        exports.collect(src, fileList, includes, excludes, null);
+
+        fileList.forEach(function(filename, index) {
+            grunt.verbose.writeln("Included:" + filename);
+        });
+        grunt.log.writeln("------------------------------------------------------------------");
+        grunt.log.writeln("Threshold configuration: lines:" + lines + "%, functions:" + functions + "%, branches:" + branches + "%");
+        grunt.log.writeln("------------------------------------------------------------------");
+
+        data.forEach(function(fileData, index) {
+            var lineThreshold = 100,
+                functionThreshold = 100,
+                branchesThreshold = 100;
+            if (fileData.lines.hit > 0) {
+                lineThreshold = fileData.lines.hit * 100 / fileData.lines.found;
+                lineThreshold = parseFloat(lineThreshold.toFixed(2));
+            }
+
+            if (fileData.functions.hit > 0) {
+                functionThreshold = fileData.functions.hit * 100 / fileData.functions.found;
+                functionThreshold = parseFloat(functionThreshold.toFixed(2));
+            }
+
+            if (fileData.branches.hit > 0) {
+                branchesThreshold = fileData.branches.hit * 100 / fileData.branches.found;
+                branchesThreshold = parseFloat(branchesThreshold.toFixed(2));
+            }
+
+            var fileName = fileData.file.replace(process.cwd(), "");
+
+            fileName = exports.normalizeFileName(fileName);
+
+            grunt.log.writeln("File:" + fileName);
+            grunt.log.write("lines:" + lineThreshold + "% | ");
+            grunt.log.write("functions:" + functionThreshold + "% | ");
+            grunt.log.write("branches:" + branchesThreshold + "% | ");
+            var excluded = isFileExcluded(fileList, fileName);
+
+            if(!excluded) {
+                if (lineThreshold >= lines && functionThreshold >= functions && branchesThreshold >= branches) {
+                    grunt.log.ok();
+                } else {
+                    grunt.log.error();
+                    pass = false;
+                }
+            } else {
+                grunt.log.ok("EXCLUDED");
+            }
+        });
+
+        fileList.forEach(function(filename, index) {
+            var representedInLcov = false;
+            data.forEach(function(fileData, index) {
+                var lcov = fileData.file.replace(process.cwd(), "");
+                lcov = exports.normalizeFileName(lcov);
+                //grunt.verbose.writeln("Comparing filenames:" + lcov +"," + filename);
+                var normalizedFileName = exports.normalizeFileName(filename.replace(process.cwd(),""));
+                if (lcov === normalizedFileName) {
+                    representedInLcov = true;
+                }
+            });
+            if (representedInLcov === false) {
+                grunt.log.error("FAILED file:" + filename + " :: Has no code coverage data. Ensure that the source file is represented in test coverage (lcov) data");
+                pass = false;
+            }
+        });
+
+        if (pass === false) {
+            grunt.fail.warn("Failed to meet code coverage threshold requirements");
+        }
+    };
+
+    /**
+     * This function checks that the included files satisfies all the configurations that 
+     * are specified in the configs object.
+     * 
+     * @param  {Array} data  An array that contains the parsed contents of the lcov file.  See
+     * @param  {Array} data  An array that contains the individual configurations for threshold validity check.  See
+     * @return {none}
+     */
+    exports.checkThresholdValidity = function(data, configs) {
+        //grunt.verbose.writeln("Processing LcovData:" + data);
+        configs.forEach(function(config) {
+            exports.checkThresholdValidityForConfig(data, config);
+        });
+    };
+
+
+    /**
+    * This function checks if the src argument is a string,  If yes: then it
+    * translates that src into an array of object representation that is used for finer
+    * code coverage configuration.  If the src object is not a string then it expects the src
+    * object to be an array of code coverage configuration. for e.g.
+    * src could either be "./src" or
+    * src could be 
+    * [{ 
+        path:"./src/todo",
+        lines: 20,
+        functions: 20,
+        includes:["./src/todo/**.js"],
+        excludes:["./src/todo/test/**.js"]
+    * },
+    * { 
+        path:"./src/feature",
+        lines: 20,
+        branches: 20,
+        includes:["./src/feature/**.js"],
+        excludes:["./src/feature/test/**.js"]
+    * }]
+    * for eg. normalizeSrcToObj("./src", 20, 20, 20,["*.js"],["abc.js"]) => [{src:"src",lines:20,functions:20,branches:20, includes:["*.js"], excludes:["abc.js"]}]
+    */
+    exports.normalizeSrcToObj = function(src, lines, functions, branches, includes, excludes) {
+        var configs = [], config ={};
+        if(typeof(src)==="string") {
+            config.path = src;
+            config.lines = lines;
+            config.functions = functions;
+            config.branches = branches;
+            config.includes = includes;
+            config.excludes = excludes;
+            configs.push(config);
+        } else if(Array.isArray(src)) {//typeof is of array... or has push method
+            configs = src;
+            configs.forEach(function(conf) {
+
+                if(!config.lines) {
+                    conf.lines = lines;
+                }
+
+                if(!conf.functions) {
+                    conf.functions = functions;
+                }
+
+                if(!conf.branches) {
+                    conf.branches = branches;
+                }
+
+                if(!conf.includes) {
+                    conf.includes = includes;
+                }
+
+                if(!config.excludes) {
+                    conf.excludes = excludes;
+                }
+            });
+        } else {
+            grunt.fail.error("The config is not in the correct format");
+        }
+
+        configs.forEach(function(config) {
+            config.path = exports.normalizeFileName(config.path);
+        });
+        return configs;
+    };
+
+    // Make them available to requiring code.
+    return exports;
+
+}());

--- a/test/code-coverage-enforcer-test.js
+++ b/test/code-coverage-enforcer-test.js
@@ -1,0 +1,152 @@
+module.exports = (function(grunt) {
+    "use strict";
+    var util = require("../tasks/lib/code-coverage-enforcer-lib"),
+        exports = {};
+
+    exports.testNormalizeFileName = function(test) {
+        test.expect(3);
+
+        var filename = "./random_file_name.txt",
+            filename1 = "/random_file_name.txt",
+            filename2 = "random_file_name.txt";
+
+        test.equal("random_file_name.txt", util.normalizeFileName(filename), "The file name should get normalized.");
+        test.equal("random_file_name.txt", util.normalizeFileName(filename1), "The file name should get normalized.");
+        test.equal("random_file_name.txt", util.normalizeFileName(filename2), "The file name should get normalized.");
+
+        test.done();
+    };
+
+    exports.testReadFile = function(test) {
+        test.expect(2);
+
+        var filename = "./test/testFile.txt";
+
+        util.readFile(filename, function(content) {
+            test.equal("Read File Test.", content, "The file contents do not match");
+        });
+
+        test.throws(function() {
+            util.readFile("filename", null)
+        }, Error, "Could not read file.");
+        test.done();
+    };
+
+    exports.testCheckThresholdValidityForConfig = function(test) {
+        // test.expect(1);
+
+        var item = [{
+                file: "/Users/hsomani/githubProjects/grunt-code-coverage-enforcer/tasks/code-coverage-enforcer.js",
+                lines: {
+                    found: 20,
+                    hit: 10
+                },
+                functions: {
+                    hit: 10,
+                    found: 20
+                },
+                branches: {
+                    hit: 10,
+                    found: 20
+                }
+            }],
+            options = {
+                path: process.cwd(),
+                includes: ["tasks/**.js"],
+                excludes: ["tasks/lib/**.js"],
+                lines: 60,
+                functions: 50,
+                branches: 50
+            };
+
+
+        test.throws(function() {
+            util.checkThresholdValidityForConfig(item, options);
+        }, Error, "Threshold not met test.");
+        test.done();
+    };
+
+    exports.testCheckThresholdValidity = function(test) {
+        // test.expect(1);
+
+        var item = [{
+                file: "/Users/hsomani/githubProjects/grunt-code-coverage-enforcer/tasks/code-coverage-enforcer.js",
+                lines: {
+                    found: 20,
+                    hit: 10
+                },
+                functions: {
+                    hit: 10,
+                    found: 20
+                },
+                branches: {
+                    hit: 10,
+                    found: 20
+                }
+            }],
+            options = [{
+                path: process.cwd(),
+                includes: ["tasks/**.js"],
+                excludes: ["tasks/lib/**.js"],
+                lines: 40,
+                functions: 40,
+                branches: 40
+            }, {
+                path: process.cwd(),
+                includes: ["tasks/**.js"],
+                excludes: ["tasks/lib/**.js"],
+                lines: 40,
+                functions: 40,
+                branches: 40
+            }];
+
+
+        util.checkThresholdValidity(item, options);
+        test.done();
+    };
+
+    exports.testNormalizeSrcToObjBaseCase = function(test) {
+        test.expect(1);
+        var src = process.cwd(),
+            functions = 20,
+            branches = 20,
+            lines = 20,
+            includes = ["/**.js", "/**.js"],
+            excludes = ["/**.js", "/**.js"],
+            returnValue, testValue = [{
+                path: process.cwd().substring(1),
+                lines : 20,
+                functions : 20,
+                branches : 20,
+                includes : ["/**.js", "/**.js"],
+                excludes : ["/**.js", "/**.js"]
+            }];
+        returnValue = util.normalizeSrcToObj(src, lines, functions, branches, includes, excludes);
+        test.strictEqual(JSON.stringify(returnValue), JSON.stringify(testValue), "The base case works");
+        test.done();
+    };
+
+    exports.testNormalizeSrcToObjBaseCase = function(test) {
+        test.expect(1);
+        var src = process.cwd(),
+            functions = 20,
+            branches = 20,
+            lines = 20,
+            includes = ["/**.js", "/**.js"],
+            excludes = ["/**.js", "/**.js"],
+            returnValue, testValue = [{
+                path: process.cwd().substring(1),
+                lines : 20,
+                functions : 20,
+                branches : 20,
+                includes : ["/**.js", "/**.js"],
+                excludes : ["/**.js", "/**.js"]
+            }];
+        returnValue = util.normalizeSrcToObj(src, lines, functions, branches, includes, excludes);
+        test.strictEqual(JSON.stringify(returnValue), JSON.stringify(testValue), "The base case works");
+        test.done();
+    };
+
+    return exports;
+
+}());

--- a/test/testFile.txt
+++ b/test/testFile.txt
@@ -1,0 +1,1 @@
+Read File Test.


### PR DESCRIPTION
1.  Updated the version information in package.json to 0.2.0
2.  Moved some of the code from tasks/code-coverage-enforcer.js to tasks/lib/code-coverage-enforcer-lib.js
3.  Updated the code in code-coverage-enforcer-lib.js to support multiple code coverage threshold configurations for different pieces of sources in the same project
4.  Added some tests in test/code-coverage-enforcer-test.js
5.  Added a file that is used by the tests.

The multiple configuration should use the property path to specify the source and not the property "src" as was the case in previous versions.