### PR TITLE
Fix issue where 0 provided for branches/lines/functions in folder lev…

### DIFF
--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -511,15 +511,15 @@ module.exports = (function() {
             configs = src;
             configs.forEach(function(conf) {
 
-                if(!conf.hasOwnProperty("lines")) {
+                if(conf.lines === null || conf.lines === undefined) {
                     conf.lines = lines;
                 }
 
-                if(!conf.hasOwnProperty("functions")) {
+                if(conf.functions === null || conf.functions === undefined) {
                     conf.functions = functions;
                 }
 
-                if(!conf.hasOwnProperty("branches")) {
+                if(conf.branches === null || conf.branches === undefined) {
                     conf.branches = branches;
                 }
 

--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -41,7 +41,7 @@ module.exports = (function() {
     // Add public functions to exports object to be used by the Grunt integration.
     var exports = {};
 
-    /* 
+    /*
      * This method is a decorator used to normalize the file names that are created by LCOV reporters. For ex. Intern's default LCOV reporter
      * has the filename when it is in the current folder but Karma add as ./ in front of the file
      */
@@ -459,9 +459,9 @@ module.exports = (function() {
     };
 
     /**
-     * This function checks that the included files satisfies all the configurations that 
+     * This function checks that the included files satisfies all the configurations that
      * are specified in the configs object.
-     * 
+     *
      * @param  {Array} data  An array that contains the parsed contents of the lcov file.  See
      * @param  {Array} data  An array that contains the individual configurations for threshold validity check.  See
      * @return {none}
@@ -480,15 +480,15 @@ module.exports = (function() {
     * code coverage configuration.  If the src object is not a string then it expects the src
     * object to be an array of code coverage configuration. for e.g.
     * src could either be "./src" or
-    * src could be 
-    * [{ 
+    * src could be
+    * [{
         path:"./src/todo",
         lines: 20,
         functions: 20,
         includes:["./src/todo/**.js"],
         excludes:["./src/todo/test/**.js"]
     * },
-    * { 
+    * {
         path:"./src/feature",
         lines: 20,
         branches: 20,
@@ -511,15 +511,15 @@ module.exports = (function() {
             configs = src;
             configs.forEach(function(conf) {
 
-                if(!conf.lines) {
+                if(!conf.hasOwnProperty("lines")) {
                     conf.lines = lines;
                 }
 
-                if(!conf.functions) {
+                if(!conf.hasOwnProperty("functions")) {
                     conf.functions = functions;
                 }
 
-                if(!conf.branches) {
+                if(!conf.hasOwnProperty("branches")) {
                     conf.branches = branches;
                 }
 

--- a/test/code-coverage-enforcer-test.js
+++ b/test/code-coverage-enforcer-test.js
@@ -147,6 +147,32 @@ module.exports = (function(grunt) {
         test.done();
     };
 
+    exports.testNormalizeSrcToObjWithNumericOverridesContainingZero = function(test) {
+        test.expect(1);
+
+        var functions = 20,
+            branches = 20,
+            lines = 20,
+            includes = ["/**.js", "/**.js"],
+            excludes = ["/**.js", "/**.js"],
+            testValue = [{
+                path: process.cwd().substring(1),
+                lines : 0,
+                functions : 0,
+                branches : 0,
+                includes : ["/**.js", "/**.js"],
+                excludes : ["/**.js", "/**.js"]
+            }],
+            expectedValue = JSON.stringify(testValue),
+            returnValue;
+
+        returnValue = util.normalizeSrcToObj(testValue, lines, functions, branches, includes, excludes);
+
+        test.strictEqual(JSON.stringify(returnValue), expectedValue, "Overrides provided in the config should be respected even if numeric values are 0.");
+
+        test.done();
+    };
+
     return exports;
 
 }());


### PR DESCRIPTION
…el config is ignored.

Cause: The checks for the presence of the value were just checking for falseness. 0 is a falsy value hence it was being replaced by the defaults.

Solution: For numeric values, check for the presence of the property using hasOwnProperty rather than check for falseness.