### PR TITLE
Typo in console output ('Exludes' should be 'Excludes').

### DIFF
--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -249,7 +249,7 @@ module.exports = (function() {
         //grunt.verbose.writeln("  testing for excludes");
 
         if (excludes && exports.isMatched(fp, excludes)) {
-            grunt.log.writeln("Exluded: " + fp);
+            grunt.log.writeln("Excluded: " + fp);
             return;
         }
 


### PR DESCRIPTION
Just a very trivial typo in console output, though it never hurts to look shiny and polished!