### PR TITLE
Added config option 'extension' to enable builds to fail on coverage for non-js files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ intern:  {
 
 
 
-### Sample Karma config
+### Sample Karma config 
 (http://karma-runner.github.io/0.8/config/coverage.html)
 ```js
 coverageReporter = {
@@ -62,7 +62,7 @@ coverageReporter = {
 }
 ```
 
-### Sample Istanbul config
+### Sample Istanbul config 
 (https://github.com/gotwarlost/istanbul, https://www.npmjs.org/package/grunt-istanbul-coverage, https://www.npmjs.org/package/grunt-mocha-istanbul)
 
 Cli version of istanbul has a report parameter that you need to set to lcov or lcovonly. By default it should generate the lcov files.
@@ -78,7 +78,7 @@ Here is one suc example for the grunt-mocha-istanbul plugin
 
 ### Mocha
 Mocha has an lcov reporter that can be foounf here https://nodejsmodules.org/pkg/mocha-lcov-reporter
-You can also use istanbul with Mocha using the plugin here
+You can also use istanbul with Mocha using the plugin here 
 https://github.com/pocesar/grunt-mocha-istanbul
 
 
@@ -107,7 +107,7 @@ grunt.initConfig({
 })
 ```
 
-the default threshold values are
+the default threshold values are 
 ```js
           {
             lines: 50,
@@ -211,7 +211,7 @@ A regular expression used for matching the file extensions of source files that 
 ### Usage Examples
 
 #### Default Options
-In this example, the default options are used
+In this example, the default options are used 
 
 ```js
 grunt.initConfig({
@@ -254,18 +254,18 @@ grunt.initConfig({
         functions: 60, // Global function coverage configuration
         branches: 60, // Global branch coverage configuration
         src: [{
-          path:"middleware",
+          path:"middleware", 
           lines:90
         }, {
-          path:"backend",
-          lines: 90,
+          path:"backend", 
+          lines: 90, 
           functions: 80
         }, {
-          path:"frontend",
-          lines: 90,
+          path:"frontend", 
+          lines: 90, 
           functions: 80,
-          branches:70,
-          includes:["**.js"],
+          branches:70, 
+          includes:["**.js"], 
           excludes:["frontend/exclude.js"]
         }
         includes: ["src/**/*.js"],
@@ -286,7 +286,7 @@ If any of the configuration option is not provided for a given folder/package, t
 
 We recommend using a specific task names build acceptance that will run the code-coverage-enforcer along with other build acceptance type of tasks.
 
-Here is an example config that should go into your Gruntfile
+Here is an example config that should go into your Gruntfile 
 ```js
 
     grunt.registerTask("build-acceptance", ["code-coverage-enforcer"]);
@@ -314,6 +314,6 @@ June 19 2014
 Initial Release.
 
 ## License
-Copyright (c) 2014 Intuit Inc.
+Copyright (c) 2014 Intuit Inc. 
 
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ intern:  {
 
 
 
-### Sample Karma config 
+### Sample Karma config
 (http://karma-runner.github.io/0.8/config/coverage.html)
 ```js
 coverageReporter = {
@@ -62,7 +62,7 @@ coverageReporter = {
 }
 ```
 
-### Sample Istanbul config 
+### Sample Istanbul config
 (https://github.com/gotwarlost/istanbul, https://www.npmjs.org/package/grunt-istanbul-coverage, https://www.npmjs.org/package/grunt-mocha-istanbul)
 
 Cli version of istanbul has a report parameter that you need to set to lcov or lcovonly. By default it should generate the lcov files.
@@ -78,7 +78,7 @@ Here is one suc example for the grunt-mocha-istanbul plugin
 
 ### Mocha
 Mocha has an lcov reporter that can be foounf here https://nodejsmodules.org/pkg/mocha-lcov-reporter
-You can also use istanbul with Mocha using the plugin here 
+You can also use istanbul with Mocha using the plugin here
 https://github.com/pocesar/grunt-mocha-istanbul
 
 
@@ -107,7 +107,7 @@ grunt.initConfig({
 })
 ```
 
-the default threshold values are 
+the default threshold values are
 ```js
           {
             lines: 50,
@@ -201,12 +201,17 @@ files below 40% whose coverage dropped in the needs attention section and contin
 with existing coverage more than 40%.  Needless to mention that the way the task would know the previous coverage configuration is if you tell this task
 what the existing coverage are by passing the information in 'src' option
 
+#### extension
+Type: `regex`
+Default value: `/\.js$/`
+
+A regular expression used for matching the file extensions of source files that are to be included.
 
 
 ### Usage Examples
 
 #### Default Options
-In this example, the default options are used 
+In this example, the default options are used
 
 ```js
 grunt.initConfig({
@@ -249,18 +254,18 @@ grunt.initConfig({
         functions: 60, // Global function coverage configuration
         branches: 60, // Global branch coverage configuration
         src: [{
-          path:"middleware", 
+          path:"middleware",
           lines:90
         }, {
-          path:"backend", 
-          lines: 90, 
+          path:"backend",
+          lines: 90,
           functions: 80
         }, {
-          path:"frontend", 
-          lines: 90, 
+          path:"frontend",
+          lines: 90,
           functions: 80,
-          branches:70, 
-          includes:["**.js"], 
+          branches:70,
+          includes:["**.js"],
           excludes:["frontend/exclude.js"]
         }
         includes: ["src/**/*.js"],
@@ -281,7 +286,7 @@ If any of the configuration option is not provided for a given folder/package, t
 
 We recommend using a specific task names build acceptance that will run the code-coverage-enforcer along with other build acceptance type of tasks.
 
-Here is an example config that should go into your Gruntfile 
+Here is an example config that should go into your Gruntfile
 ```js
 
     grunt.registerTask("build-acceptance", ["code-coverage-enforcer"]);
@@ -309,6 +314,6 @@ June 19 2014
 Initial Release.
 
 ## License
-Copyright (c) 2014 Intuit Inc. 
+Copyright (c) 2014 Intuit Inc.
 
 Licensed under the MIT license.

--- a/tasks/code-coverage-enforcer.js
+++ b/tasks/code-coverage-enforcer.js
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
         options.excludes = util.normalizeOSPath(options.excludes);
 
         //Adapt the original options to the list of configs that will be used for validating the code coverage.
-        options.src = util.normalizeSrcToObj(options.src, options.lines, options.functions, options.branches, options.includes, options.excludes, options.filter);
+        options.src = util.normalizeSrcToObj(options.src, options.lines, options.functions, options.branches, options.includes, options.excludes, options.extension);
         // options.src = util.normalizeOSPath(options.src);
 
         if (options.lcovfile) {

--- a/tasks/code-coverage-enforcer.js
+++ b/tasks/code-coverage-enforcer.js
@@ -59,7 +59,8 @@ module.exports = function (grunt) {
             lines: 50,
             functions: 50,
             branches: 0,
-            includes: ["**/*.js"],
+            includes: ["**/*.js", "**/*.jsx"],
+            extension: /\.js$|\.jsx$/,
             src: process.cwd(), //array { path: "",thresholds: {} }
             excludes: [],
             logCurrentCoverage: false,

--- a/tasks/lib/code-coverage-enforcer-lib.js
+++ b/tasks/lib/code-coverage-enforcer-lib.js
@@ -121,13 +121,14 @@ module.exports = (function () {
      * @param {array}  files   a pointer to an array that stores a list of files
      * @param {array}  includes a list of patterns for files to match
      * @param {array}  excludes a list of patterns for files to ignore
+     * @param {string} extension    an optional regular expression for matching file extensions
      *
      * collect(options.src, fileList, options.includes, options.excludes, null);
      */
-    exports.collect = function (fp, files, includes, excludes, replaceDirectory) {
+    exports.collect = function (fp, files, includes, excludes, replaceDirectory, extension) {
         if (shjs.test("-d", fp)) {
             shjs.find(fp).filter(function (file) {
-                if (file.match(/\.js$/)) {
+                if (file.match(extension || /\.js$/)) {
                     files.push(file);
                 }
             });
@@ -217,6 +218,7 @@ module.exports = (function () {
             branches = config.branches,
             includes = config.includes,
             excludes = config.excludes,
+            extension = config.extension,
             pass = true,
             length = data.length,
             fileList = [],
@@ -228,7 +230,7 @@ module.exports = (function () {
                 needsAttentionFiles: []
             };
         validityResults.config = config;
-        fileList = exports.collect(src, fileList, includes, excludes, homeDirectory);
+        fileList = exports.collect(src, fileList, includes, excludes, homeDirectory, extension);
         fileList.forEach(function (filename, index) {
             var fName = exports.normalizeFileName(filename.replace(homeDirectory, ""));
             var fileData = data[fName];
@@ -400,7 +402,7 @@ module.exports = (function () {
     * }]
     * for eg. normalizeSrcToObj("./src", 20, 20, 20,["*.js"],["abc.js"]) => [{src:"src",lines:20,functions:20,branches:20, includes:["*.js"], excludes:["abc.js"]}]
     */
-    exports.normalizeSrcToObj = function (src, lines, functions, branches, includes, excludes) {
+    exports.normalizeSrcToObj = function (src, lines, functions, branches, includes, excludes, extension) {
         var configs = [],
             config = {};
         if (typeof (src) === "string") {
@@ -410,6 +412,7 @@ module.exports = (function () {
             config.branches = branches;
             config.includes = includes;
             config.excludes = excludes;
+            config.extension = extension;
             configs.push(config);
         } else if (Array.isArray(src)) { //typeof is of array... or has push method
             configs = src;
@@ -428,6 +431,9 @@ module.exports = (function () {
                 }
                 if (!conf.excludes) {
                     conf.excludes = excludes;
+                }
+                if (typeof conf.extension) {
+                    conf.extension = extension;
                 }
                 conf.path = exports.normalizeFileName(conf.path);
             });


### PR DESCRIPTION
Rather than adding adding this as a config option, it might make sense for all files to be matched by default, since the suggested practice in the README seems to be to include "*.js" explicity in the **include** option anyways.

I would be happy to take either approach.